### PR TITLE
Add possibility to lock rename for followers

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -155,6 +155,7 @@ namespace ClassicUO.Configuration
         public bool GameWindowFullSize { get; set; }
         public bool WindowBorderless { get; set; } = false;
         public Point GameWindowSize { get; set; } = new Point(600, 480);
+        public bool LockFollowerRename { get; set; } = false;
         public Point TopbarGumpPosition { get; set; } = new Point(0, 0);
         public bool TopbarGumpIsMinimized { get; set; }
         public bool TopbarGumpIsDisabled { get; set; }

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -53,6 +53,7 @@ namespace ClassicUO.Game.UI.Gumps
     internal abstract class BaseHealthBarGump : AnchorableGump
     {
         private bool _targetBroke;
+        private bool ShowEdit => Keyboard.Ctrl && Keyboard.Alt && ProfileManager.CurrentProfile.LockFollowerRename;
 
         protected BaseHealthBarGump(Entity entity) : this(0, 0)
         {
@@ -157,7 +158,7 @@ namespace ClassicUO.Game.UI.Gumps
                 TargetManager.Target(LocalSerial);
                 Mouse.LastLeftButtonClickTime = 0;
             }
-            else if (_canChangeName && !_targetBroke)
+            else if (_canChangeName && !_targetBroke && (!ProfileManager.CurrentProfile.LockFollowerRename || ShowEdit))
             {
                 _textBox.IsEditable = true;
                 _textBox.SetKeyboardFocus();

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -164,6 +164,7 @@ namespace ClassicUO.Game.UI.Gumps
         private InputField _spellFormatBox;
         private ClickableColorBox _tooltip_font_hue;
         private FontSelector _tooltip_font_selector;
+        private Checkbox _lockFollowerRename;
 
         // video
         private Checkbox _use_old_status_gump, _windowBorderless, _enableDeathScreen, _enableBlackWhiteEffect, _altLights, _enableLight, _enableShadows, _enableShadowsStatics, _auraMouse, _runMouseInSeparateThread, _useColoredLights, _darkNights, _partyAura, _hideChatGradient;
@@ -873,6 +874,17 @@ namespace ClassicUO.Game.UI.Gumps
                 )
             );
 
+            section2.Add
+            (
+                _lockFollowerRename = AddCheckBox(
+                    null,
+                    ResGumps.LockRenameFollower,
+                    _currentProfile.LockFollowerRename,
+                    0,
+                    0
+                )
+            );
+
             section2.Add(AddLabel(null, ResGumps.AuraUnderFeet, startX, startY));
 
             section2.AddRight
@@ -920,7 +932,7 @@ namespace ClassicUO.Game.UI.Gumps
                     ResGumps.PartyAuraColor
                 )
             );
-
+            
             section2.AddRight(AddLabel(null, ResGumps.PartyAuraColor, 0, 0));
             section2.PopIndent();
             section2.PopIndent();
@@ -3803,6 +3815,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             _currentProfile.ShowNewMobileNameIncoming = _showMobileNameIncoming.IsChecked;
             _currentProfile.ShowNewCorpseNameIncoming = _showCorpseNameIncoming.IsChecked;
+            _currentProfile.LockFollowerRename = _lockFollowerRename.IsChecked;
             _currentProfile.GridLootType = _gridLoot.SelectedIndex;
             _currentProfile.SallosEasyGrab = _sallosEasyGrab.IsChecked;
             _currentProfile.PartyInviteGump = _partyInviteGump.IsChecked;

--- a/src/Resources/ResGumps.Designer.cs
+++ b/src/Resources/ResGumps.Designer.cs
@@ -2277,6 +2277,15 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Lock Rename Follower (Ctrl + Alt to rename).
+        /// </summary>
+        public static string LockRenameFollower {
+            get {
+                return ResourceManager.GetString("LockRenameFollower", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Login music.
         /// </summary>
         public static string LoginMusic {

--- a/src/Resources/ResGumps.resx
+++ b/src/Resources/ResGumps.resx
@@ -1552,4 +1552,7 @@ Client version: '{0}'</value>
   <data name="DragSelectStartingPosY" xml:space="preserve">
     <value>Starting Y position of health bars</value>
   </data>
+  <data name="LockRenameFollower" xml:space="preserve">
+    <value>Lock Rename Follower (Ctrl + Alt to rename)</value>
+  </data>
 </root>


### PR DESCRIPTION
Add possibility to lock rename options for HealtBars
User can still edit it when pressing Ctrl+Alt
![lockFollowerRename](https://user-images.githubusercontent.com/17531612/128984717-9596c6e7-97f2-4733-8787-0220da3e8b1d.gif)
