### PR TITLE
Fix issue with robe after dead

### DIFF
--- a/src/Game/GameObjects/Views/MobileView.cs
+++ b/src/Game/GameObjects/Views/MobileView.cs
@@ -881,6 +881,7 @@ namespace ClassicUO.Game.GameObjects
                     return robe != null && robe.Graphic != 0 && robe.Graphic != 0x9985 && robe.Graphic != 0x9986 && robe.Graphic != 0xA412;
 
                 case Layer.Helmet:
+                case Layer.Beard:
                 case Layer.Hair:
                     robe = mobile.FindItemByLayer(Layer.Robe);
 


### PR DESCRIPTION
After the player died, a robe appeared on the robe of death:

![image](https://user-images.githubusercontent.com/17531612/130191379-c36db173-fb90-4b99-868a-cd6ddb12159c.png)


The reason was to wear a beard that, when converted to GumpId, existed.
Added Layer.Beard to ignore item